### PR TITLE
Add sitemap and atom feed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,8 @@ jobs:
       - uses: dart-lang/setup-dart@v1.3
       - name: Get dependencies
         run: dart pub get
-      - name: Run initial build
-        run: dart run build_runner build --release
-      - name: Copy into output directory
-        run: dart run build_runner build --release --output web:_site
+      - name: Build website
+        run: dart run tool/build.dart
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ To then copy generated contents into the desired directory, use:
 dart run build_runner build --release --output web:_site
 ```
 
+Or, just run `dart run tool/build.dart` which takes care of this for you and
+also includes the current time in the atom feed.
+
 ## License and disclaimers
 
 Except as otherwise noted, the textual contents of this project are licensed

--- a/pages/atom.html
+++ b/pages/atom.html
@@ -1,0 +1,32 @@
+---
+path: atom.xml
+data:
+  hidden: true
+---
+<?xml version="1.0"?>
+{% assign section = 'issues/index.html' | sectionOf %}
+{% assign children = section.pages | sortedByWeight  %}
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>This Week in Dart</title>
+  <author><name>Parker Lougheed</name></author>
+  <link type="application/atom+xml" rel="self" href="{{ '' | pageUrl }}"/>
+  <id>{{ '' | pageUrl }}</id>
+  <contributor><name>This Week in Dart contributors</name></contributor>
+  <rights type="html">
+    Made available by Parker Lougheed and Contributors under the &lt;a href=&quot;http://creativecommons.org/licenses/by/4.0/&quot;&gt;Creative Commons Attribution 4.0 License&lt;/a&gt;
+  </rights>
+  <updated>{{ built_site.config.build_time | default: (site.last_updated | append: 'T00:00:00Z') }}</updated>
+
+  {% for child in children %}
+    {% if child != section.index %}
+      {% assign page = child | pageInfo %}
+      <entry>
+        <title>{{ page.data.title }}</title>
+        <link rel="alternate" type="text/html" href="{{ child | pageUrl }}" />
+        <id>{{ child | pageUrl }}</id>
+        <summary type="text">{{ page.data.description | default: page.data.title }}</summary>
+        <updated>{{ page.data.date }}T00:00:00Z</updated>
+      </entry>
+    {% endif %}
+  {% endfor %}
+</feed>

--- a/pages/index.html
+++ b/pages/index.html
@@ -30,7 +30,7 @@ on the [Unofficial Dart Community Discord](https://discord.gg/Qt6DgfAWWx).
     {% assign section = 'issues/index.html' | sectionOf %}
     {% assign children = section.children | concat: section.pages | sortedByWeight  %}
     {% assign i = 1 %}
-    {% for child in children reversed %}
+    {% for child in children | reverse %}
     {% if child == section.index %}
     {% continue %}
     {% endif %}

--- a/pages/issues/index.html
+++ b/pages/issues/index.html
@@ -20,7 +20,7 @@ in reverse historical order.
     {% assign section = page_section %}
     {% assign children = section.children | concat: section.pages | sortedByWeight %}
 
-    {% for child in children reversed %}
+    {% for child in children | reverse %}
     {% if child == section.index %}
     {% continue %}
     {% endif %}

--- a/pages/sitemap.html
+++ b/pages/sitemap.html
@@ -1,0 +1,16 @@
+---
+path: sitemap.xml
+data:
+  hidden: true
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    {% for page in pages %}
+        {% assign info = page | pageInfo %}
+        {% if info.data.hidden != true %}
+            <url>
+                <loc>{{info.path | absUrl}}</loc>
+            </url>
+        {% endif %}
+    {% endfor %}
+</urlset>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,5 +11,5 @@ dev_dependencies:
   build_web_compilers: ^3.2.3
   built_site:
     hosted: https://simonbinder.eu
-    version: ^0.2.5
+    version: ^0.2.6
   webdev: ^2.7.8

--- a/templates/partials/head.html
+++ b/templates/partials/head.html
@@ -9,7 +9,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wght@8..144,400;8..144,700&display=swap" rel="stylesheet">
-
+    <link rel="alternate" type="application/atom+xml" href="{{ '/atom.xml' | absUrl }}">
+    <link rel="sitemap" href="{{ '/sitemap.xml' | absUrl }}">
     <link href="/main.css" rel="stylesheet">
     <script src="/main.js" defer></script>
 </head>

--- a/tool/build.dart
+++ b/tool/build.dart
@@ -1,0 +1,42 @@
+import 'dart:io';
+
+Future<void> main() async {
+  final time = DateTime.now().toUtc().toIso8601String();
+  final dartExecutable = Platform.executable;
+
+  // We generate an atom feed, which is required to include a timestamp of when
+  // it was updated. Builds need to be deterministic though, so a builder can't
+  // use `DateTime.now()` in an output. We work around this by passing the
+  // current time as a build option to `built_site`, which means that we can
+  // read it through `{{ built_site.config.build_time }}` in Liquid.
+  final define = '--define=built_site=build_time=$time';
+
+  await _runProcess(dartExecutable, [
+    'run',
+    'build_runner',
+    'build',
+    '--release',
+    define,
+  ]);
+
+  await _runProcess(dartExecutable, [
+    'run',
+    'build_runner',
+    'build',
+    '--release',
+    define,
+    '--output',
+    'web:_site',
+  ]);
+}
+
+Future<void> _runProcess(String executable, List<String> args) async {
+  print('Running $executable ${args.join(' ')}');
+
+  final process = await Process.start(executable, args,
+      mode: ProcessStartMode.inheritStdio);
+  final exitCode = await process.exitCode;
+  if (exitCode != 0) {
+    exit(exitCode);
+  }
+}

--- a/website.yaml
+++ b/website.yaml
@@ -1,7 +1,13 @@
+site:
+  # Note: This serves as a default value for the last update timestamp. Builds
+  # need to be deterministic, so we can't emit `DateTime.now()` into generated
+  # files. We pass a build option via `--define=built_site=build_time=<now>`.
+  last_updated: "2022-05-09"
+
 environments:
   dev:
     minify: false
     base_url: "http://localhost:8080/"
   prod:
     minify: true
-    base_url: ""
+    base_url: "https://thisweekindart.dev"


### PR DESCRIPTION
Add a sitemap and an atom feed to the website, and link them from each page.

The sitemap contains all pages, I've setup the atom feed to only list issues since those are include a publishing date. Atom feeds require an `updated` timestamp for the feed and each entry, so having a rough date available is helpful.

Builds are deterministic, so I had to come up with a workaround to include the current build time in the atom feed: We can pass builder options with `--define` to `build_runner build`, so I wrote a small script to wrap the build with a define to include the current time. I've also pushed an update to `built_site` which makes builder options available with `built_site.config`, which means that we can get the current time through that without violating build contracts.