### PR TITLE
Simplify build setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,21 +17,15 @@ on the [Unofficial Dart Community Discord](https://discord.gg/Qt6DgfAWWx).
 
 ## Running the site
 
-To run a development version of the site locally, run: 
+To run a development version of the site locally, run:
 
 ```shell
-dart run webdev serve pages:9999 web:8080 --auto refresh
+dart run build_runner serve --live-reload
 ```
 
 ## Building the site
 
-To build a production version of the site, first run:
-
-```shell
-dart run build_runner build --release
-```
-
-To then copy generated contents into the desired directory, use:
+To build a production version of the site, simply run:
 
 ```shell
 dart run build_runner build --release --output web:_site

--- a/build.yaml
+++ b/build.yaml
@@ -13,3 +13,7 @@ targets:
         - "website.yaml"
       exclude:
         - "pages/**/_*"
+
+additional_public_assets:
+  # This tells build_runner that these files are part of the default build
+  - "pages/**"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,4 +13,3 @@ dev_dependencies:
     git:
       url: https://github.com/simolus3/built_site.git
       path: built_site
-  webdev: ^2.7.9

--- a/tool/build.dart
+++ b/tool/build.dart
@@ -17,14 +17,6 @@ Future<void> main() async {
     'build',
     '--release',
     define,
-  ]);
-
-  await _runProcess(dartExecutable, [
-    'run',
-    'build_runner',
-    'build',
-    '--release',
-    define,
     '--output',
     'web:_site',
   ]);


### PR DESCRIPTION
I _finally_ managed to figure out what's causing pages to not get built by default and managed to land a much more convenient workaround in `build_runner_core: ^7.2.7`.

You'll probably need to run `dart pub upgrade` first (not sure if I should add an explicit dependency), but we can finally remove all the additional ports from the build script.