### PR TITLE
Include page content in atom feed

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -21,9 +21,19 @@ targets:
         - "website.yaml"
       exclude:
         - "pages/**/_*"
+        - "pages/atom.html"
     builders:
       :index_issues:
         enabled: true
+      built_site:
+        options:
+          emit_content_file: true
+
+  atom_feed:
+    dependencies: ["$default"]
+    sources:
+      include:
+        - pages/atom.*
 
 additional_public_assets:
   # This tells build_runner that these files are part of the default build

--- a/pages/atom.html
+++ b/pages/atom.html
@@ -17,16 +17,19 @@ data:
   </rights>
   <updated>{{ built_site.config.build_time | default: (site.last_updated | append: 'T00:00:00Z') }}</updated>
 
-  {%- for child in children -%}
-    {%- if child != section.index -%}
-      {%- assign page = child | pageInfo %}
-      <entry>
-        <title>{{ page.data.title }}</title>
-        <link rel="alternate" type="text/html" href="{{ child | pageUrl }}" />
-        <id>{{ child | pageUrl }}</id>
-        <summary type="text">{{ page.data.description | default: page.data.title }}</summary>
-        <updated>{{ page.data.date }}T00:00:00Z</updated>
-      </entry>
-    {%- endif -%}
-  {% endfor %}
+  {%- assign issues = 'package:thisweekindart/all.json' | readString | json_decode -%}
+  {%- for entry in issues.issues offset: (issues.issues | length | minus: 3) reversed -%}
+    {%- assign page = entry | pageInfo %}
+    {%- assign contentId = entry | changeExtension: '.page_content' -%}
+    <entry>
+      <title>{{ page.data.title }}</title>
+      <link rel="alternate" type="text/html" href="{{ entry | pageUrl }}" />
+      <id>{{ entry | pageUrl }}</id>
+      <summary type="text">{{ page.data.description | default: page.data.title }}</summary>
+      <updated>{{ page.data.date }}T00:00:00Z</updated>
+      <content type="html">
+        <![CDATA[{{- contentId | readString -}}]]>
+      </content>
+    </entry>
+  {%- endfor -%}
 </feed>


### PR DESCRIPTION
I saw @kevmoo's suggestion on Twitter and wanted to see how much it takes to implement this :)

With this PR, we only render the last three issues in the atom feed, but include the issue's content in the feed. Not listing all issues is what other websites having content in their feeds seem to do as well. After all, we still have the `sitemap.xml`.

I had to make some changes to `built_site` for this - a new build option will make it emit a page's content _before_ applying its full template in a separate file. So, I just make sure that all issues get built before the atom feed and then read those generated contents in there.

I _think_ this format is standard compliant, at least it looks pretty decent in Thunderbird:

![The atom feed with content in Thunderbird](https://user-images.githubusercontent.com/5738860/207729814-ae412711-6eaa-43fd-9bfb-90c206d264ac.png)
